### PR TITLE
feat(chat): add AI Studio chatbot (multi-model, tools, billing-gated)

### DIFF
--- a/app/[locale]/chat/page.tsx
+++ b/app/[locale]/chat/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import DashboardShell from "@/components/DashboardShell";
+import ChatClient from "@/components/chat/ChatClient";
+
+export default function ChatPage() {
+  return (
+    <DashboardShell>
+      <div className="p-4">
+        <ChatClient />
+      </div>
+    </DashboardShell>
+  );
+}

--- a/app/api/chat/conversations/[id]/route.ts
+++ b/app/api/chat/conversations/[id]/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { requireAuth, unauthorizedResponse } from "@/lib/auth0";
+
+export const dynamic = "force-dynamic";
+
+async function ownConversation(userId: string, id: string) {
+  return prisma.chatConversation.findFirst({
+    where: { id, userId },
+    select: { id: true },
+  });
+}
+
+// PATCH /api/chat/conversations/[id] → rename a conversation.
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  let user;
+  try {
+    user = await requireAuth();
+  } catch {
+    return unauthorizedResponse();
+  }
+
+  const { id } = await params;
+  if (!(await ownConversation(user.id, id))) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  let body: { title?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  const title = (body.title || "").trim();
+  if (!title) {
+    return NextResponse.json({ error: "Title required" }, { status: 400 });
+  }
+
+  const updated = await prisma.chatConversation.update({
+    where: { id },
+    data: { title: title.slice(0, 120) },
+    select: { id: true, title: true, model: true, updatedAt: true },
+  });
+
+  return NextResponse.json({ conversation: updated });
+}
+
+// DELETE /api/chat/conversations/[id] → delete a conversation and its messages.
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  let user;
+  try {
+    user = await requireAuth();
+  } catch {
+    return unauthorizedResponse();
+  }
+
+  const { id } = await params;
+  if (!(await ownConversation(user.id, id))) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  await prisma.chatConversation.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/chat/conversations/route.ts
+++ b/app/api/chat/conversations/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { requireAuth, unauthorizedResponse } from "@/lib/auth0";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/chat/conversations → list the user's conversations (newest first).
+export async function GET() {
+  let user;
+  try {
+    user = await requireAuth();
+  } catch {
+    return unauthorizedResponse();
+  }
+
+  const conversations = await prisma.chatConversation.findMany({
+    where: { userId: user.id },
+    orderBy: { updatedAt: "desc" },
+    select: { id: true, title: true, model: true, updatedAt: true },
+    take: 100,
+  });
+
+  return NextResponse.json({ conversations });
+}

--- a/app/api/chat/options/route.ts
+++ b/app/api/chat/options/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { requireAuth, unauthorizedResponse } from "@/lib/auth0";
+import { getChatModelOptions } from "@/lib/chat";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/chat/options → model list (with lock flags), subscription + balance.
+export async function GET() {
+  let user;
+  try {
+    user = await requireAuth();
+  } catch {
+    return unauthorizedResponse();
+  }
+
+  const record = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: {
+      subscriptionStatus: true,
+      subscriptionTier: true,
+      creditBalanceCents: true,
+    },
+  });
+
+  const isSubscriber = record?.subscriptionStatus === "active";
+
+  return NextResponse.json({
+    models: getChatModelOptions(isSubscriber),
+    isSubscriber,
+    tier: record?.subscriptionTier ?? null,
+    balanceCents: record?.creditBalanceCents ?? 0,
+  });
+}

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,0 +1,274 @@
+import { NextRequest, NextResponse } from "next/server";
+import { streamText, stepCountIs } from "ai";
+import { prisma } from "@/lib/db";
+import { requireAuth, unauthorizedResponse } from "@/lib/auth0";
+import { getModel } from "@/lib/ai-gateway";
+import { resolveTextModel } from "@/lib/ai-models";
+import { hasCredits, deductCredits, getCreditBalance } from "@/lib/credits";
+import { trackTokenUsage } from "@/lib/usage-tracking";
+import {
+  CHAT_SOURCE,
+  HISTORY_CONTEXT_LIMIT,
+  MAX_CHAT_STEPS,
+  buildChatSystemPrompt,
+  deriveTitle,
+  toTokenUsage,
+  isPremiumChatModel,
+} from "@/lib/chat";
+import { buildChatTools } from "@/lib/chat-tools";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// GET /api/chat?conversation_id=...  → message history for one conversation
+export async function GET(req: NextRequest) {
+  let user;
+  try {
+    user = await requireAuth();
+  } catch {
+    return unauthorizedResponse();
+  }
+
+  const conversationId = req.nextUrl.searchParams.get("conversation_id");
+  if (!conversationId) {
+    return NextResponse.json({ messages: [] });
+  }
+
+  const conversation = await prisma.chatConversation.findFirst({
+    where: { id: conversationId, userId: user.id },
+    select: { id: true },
+  });
+  if (!conversation) {
+    return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+  }
+
+  const messages = await prisma.chatMessage.findMany({
+    where: { conversationId, userId: user.id },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      role: true,
+      content: true,
+      model: true,
+      toolCalls: true,
+      createdAt: true,
+    },
+  });
+
+  return NextResponse.json({ messages });
+}
+
+// POST /api/chat  → send a message, stream the assistant reply (SSE)
+export async function POST(req: NextRequest) {
+  let user;
+  try {
+    user = await requireAuth();
+  } catch {
+    return unauthorizedResponse();
+  }
+
+  if (!(await hasCredits(user.id))) {
+    return NextResponse.json(
+      {
+        error:
+          "Insufficient credits. Add credits or upgrade your plan in Settings to keep chatting.",
+        code: "INSUFFICIENT_CREDITS",
+      },
+      { status: 402 },
+    );
+  }
+
+  let body: { message?: string; conversation_id?: string; model?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const message = (body.message || "").trim();
+  if (!message) {
+    return NextResponse.json({ error: "Message required" }, { status: 400 });
+  }
+
+  const model = resolveTextModel(body.model);
+
+  // Premium flagship models require an active subscription.
+  if (isPremiumChatModel(model.id)) {
+    const sub = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { subscriptionStatus: true },
+    });
+    if (sub?.subscriptionStatus !== "active") {
+      return NextResponse.json(
+        {
+          error: `${model.label} is a premium model. Subscribe to any plan in Settings to unlock it — or pick a free/standard model to keep chatting.`,
+          code: "PREMIUM_MODEL_LOCKED",
+        },
+        { status: 403 },
+      );
+    }
+  }
+
+  // Resolve or create the conversation (verifying ownership).
+  let conversationId = body.conversation_id || null;
+  let isNewConversation = false;
+  if (conversationId) {
+    const existing = await prisma.chatConversation.findFirst({
+      where: { id: conversationId, userId: user.id },
+      select: { id: true },
+    });
+    if (!existing) {
+      return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+  } else {
+    const created = await prisma.chatConversation.create({
+      data: { userId: user.id, title: deriveTitle(message), model: model.id },
+      select: { id: true },
+    });
+    conversationId = created.id;
+    isNewConversation = true;
+  }
+
+  // Load recent history for context (chronological).
+  const history = await prisma.chatMessage.findMany({
+    where: { conversationId, userId: user.id },
+    orderBy: { createdAt: "desc" },
+    take: HISTORY_CONTEXT_LIMIT,
+    select: { role: true, content: true },
+  });
+  history.reverse();
+
+  // Persist the user's message immediately.
+  await prisma.chatMessage.create({
+    data: { conversationId, userId: user.id, role: "user", content: message },
+  });
+
+  const modelMessages = [
+    ...history.map((m) => ({
+      role: m.role as "user" | "assistant" | "system",
+      content: m.content,
+    })),
+    { role: "user" as const, content: message },
+  ];
+
+  const encoder = new TextEncoder();
+  const send = (controller: ReadableStreamDefaultController, obj: unknown) =>
+    controller.enqueue(encoder.encode(`data: ${JSON.stringify(obj)}\n\n`));
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      // Tell the client which conversation this belongs to (esp. for new ones).
+      send(controller, { type: "meta", conversationId, model: model.id, isNewConversation });
+
+      let assistantText = "";
+      const toolEvents: { tool: string; input?: unknown; output?: unknown }[] = [];
+      let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+
+      try {
+        const result = streamText({
+          model: getModel(model.id),
+          system: buildChatSystemPrompt({ userName: user.name, language: user.language }),
+          messages: modelMessages,
+          tools: buildChatTools({ userId: user.id, language: user.language }),
+          stopWhen: stepCountIs(MAX_CHAT_STEPS),
+        });
+
+        for await (const part of result.fullStream) {
+          if (part.type === "text-delta") {
+            assistantText += part.text;
+            send(controller, { type: "delta", text: part.text });
+          } else if (part.type === "tool-call") {
+            toolEvents.push({ tool: part.toolName, input: part.input });
+            send(controller, { type: "step", tool: part.toolName });
+          } else if (part.type === "tool-result") {
+            const ev = toolEvents.find((t) => t.tool === part.toolName && t.output === undefined);
+            if (ev) ev.output = part.output;
+            send(controller, { type: "step_done", tool: part.toolName });
+          } else if (part.type === "tool-error") {
+            send(controller, { type: "step_error", tool: part.toolName });
+          } else if (part.type === "finish") {
+            usage = toTokenUsage(part.totalUsage);
+          } else if (part.type === "error") {
+            throw part.error instanceof Error ? part.error : new Error(String(part.error));
+          }
+        }
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.error("[POST /api/chat] stream error:", detail);
+        if (!assistantText) {
+          assistantText = `**AI service error.** ${detail.slice(0, 300)}\n\nPlease try again, or check your API key configuration in Settings.`;
+          send(controller, { type: "delta", text: assistantText });
+        }
+      }
+
+      // Persist the assistant reply.
+      try {
+        await prisma.chatMessage.create({
+          data: {
+            conversationId: conversationId!,
+            userId: user.id,
+            role: "assistant",
+            content: assistantText || "(no response)",
+            model: model.id,
+            promptTokens: usage.promptTokens,
+            completionTokens: usage.completionTokens,
+            toolCalls: toolEvents.length > 0 ? JSON.stringify(toolEvents) : null,
+          },
+        });
+        await prisma.chatConversation.update({
+          where: { id: conversationId! },
+          data: { updatedAt: new Date(), model: model.id },
+        });
+      } catch (e) {
+        console.error("[POST /api/chat] persist error:", e);
+      }
+
+      // Track usage + deduct credits (best-effort, never block the reply).
+      let balance: number | undefined;
+      if (usage.totalTokens > 0) {
+        try {
+          await trackTokenUsage({
+            userId: user.id,
+            source: CHAT_SOURCE,
+            usage,
+            model: model.id,
+            provider: model.provider.toLowerCase(),
+          });
+          const res = await deductCredits({
+            userId: user.id,
+            usage,
+            model: model.id,
+            source: CHAT_SOURCE,
+          });
+          balance = res.newBalance;
+        } catch (e) {
+          console.error("[POST /api/chat] billing error:", e);
+        }
+      }
+      if (balance === undefined) {
+        try {
+          balance = await getCreditBalance(user.id);
+        } catch {
+          /* ignore */
+        }
+      }
+
+      send(controller, {
+        type: "done",
+        conversationId,
+        model: model.id,
+        usage,
+        balanceCents: balance,
+      });
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/components/DashboardShell.tsx
+++ b/components/DashboardShell.tsx
@@ -18,6 +18,7 @@ export default function DashboardShell({
   const tUser = useTranslations("userMenu");
   const navLinks: { href: string; label: string; highlight?: boolean; indent?: boolean }[] = [
     { href: `${prefix}/dashboard`, label: locale === "zh" ? "仪表盘" : "Dashboard" },
+    { href: `${prefix}/chat`, label: tNav("chat"), highlight: true },
     { href: `${prefix}/media-studio`, label: tNav("toolbox") },
     { href: `${prefix}/media-studio/video`, label: tNav("video"), indent: true },
     { href: `${prefix}/media-studio/gallery/generate`, label: tNav("images"), indent: true },

--- a/components/chat/ChatClient.tsx
+++ b/components/chat/ChatClient.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import ReactMarkdown from "react-markdown";
+import { useLocale } from "next-intl";
+
+interface ChatModelOption {
+  id: string;
+  label: string;
+  provider: string;
+  description?: string;
+  premium: boolean;
+  locked: boolean;
+}
+
+interface Conversation {
+  id: string;
+  title: string;
+  model: string | null;
+  updatedAt: string;
+}
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+  pending?: boolean;
+}
+
+const T = {
+  en: {
+    newChat: "New chat",
+    placeholder: "Ask xPilot anything about your social media…",
+    send: "Send",
+    empty: "Start a conversation with your marketing copilot.",
+    thinking: "Thinking…",
+    balance: "Balance",
+    locked: "Subscribe to unlock",
+    premium: "Premium",
+    rename: "Rename",
+    delete: "Delete",
+    deleteConfirm: "Delete this conversation?",
+    history: "History",
+    running: "Running",
+    suggestions: [
+      "Draft 3 tweets about our product launch",
+      "What's trending in tech today?",
+      "Plan a week of posts for my brand",
+    ],
+  },
+  zh: {
+    newChat: "新对话",
+    placeholder: "向 xPilot 询问任何社媒相关的问题…",
+    send: "发送",
+    empty: "和你的营销助手开始对话吧。",
+    thinking: "思考中…",
+    balance: "余额",
+    locked: "订阅后解锁",
+    premium: "高级",
+    rename: "重命名",
+    delete: "删除",
+    deleteConfirm: "删除这个对话？",
+    history: "历史",
+    running: "正在执行",
+    suggestions: [
+      "帮我写 3 条产品发布的推文",
+      "今天科技圈有什么热点？",
+      "帮我规划本周的发帖内容",
+    ],
+  },
+};
+
+export default function ChatClient() {
+  const locale = useLocale();
+  const t = locale === "zh" ? T.zh : T.en;
+
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState("");
+  const [streaming, setStreaming] = useState(false);
+  const [steps, setSteps] = useState<string[]>([]);
+  const [models, setModels] = useState<ChatModelOption[]>([]);
+  const [selectedModel, setSelectedModel] = useState<string>("");
+  const [balanceCents, setBalanceCents] = useState<number | null>(null);
+  const [notice, setNotice] = useState<string>("");
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = useCallback(() => {
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+    });
+  }, []);
+
+  const refreshConversations = useCallback(async () => {
+    try {
+      const res = await fetch("/api/chat/conversations");
+      if (res.ok) {
+        const data = await res.json();
+        setConversations(data.conversations || []);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  // Load model options + balance + conversation list on mount.
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/chat/options");
+        if (res.ok) {
+          const data = await res.json();
+          setModels(data.models || []);
+          setBalanceCents(typeof data.balanceCents === "number" ? data.balanceCents : null);
+          const firstUsable = (data.models as ChatModelOption[])?.find((m) => !m.locked);
+          if (firstUsable) setSelectedModel(firstUsable.id);
+        }
+      } catch {
+        /* ignore */
+      }
+      refreshConversations();
+    })();
+  }, [refreshConversations]);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, steps, scrollToBottom]);
+
+  async function loadConversation(id: string) {
+    if (streaming) return;
+    setActiveId(id);
+    setNotice("");
+    try {
+      const res = await fetch(`/api/chat?conversation_id=${id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setMessages(
+          (data.messages || []).map((m: { role: string; content: string }) => ({
+            role: m.role === "assistant" ? "assistant" : "user",
+            content: m.content,
+          })),
+        );
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  function startNewChat() {
+    if (streaming) return;
+    setActiveId(null);
+    setMessages([]);
+    setNotice("");
+  }
+
+  function setLastAssistant(content: string) {
+    setMessages((prev) => {
+      const next = [...prev];
+      for (let i = next.length - 1; i >= 0; i--) {
+        if (next[i].role === "assistant") {
+          next[i] = { role: "assistant", content };
+          break;
+        }
+      }
+      return next;
+    });
+  }
+
+  async function send(text?: string) {
+    const msg = (text ?? input).trim();
+    if (!msg || streaming) return;
+    setInput("");
+    setNotice("");
+    setMessages((prev) => [
+      ...prev,
+      { role: "user", content: msg },
+      { role: "assistant", content: "", pending: true },
+    ]);
+    setStreaming(true);
+    setSteps([]);
+
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: msg, conversation_id: activeId, model: selectedModel }),
+      });
+
+      if (!res.ok || !res.body) {
+        const err = await res.json().catch(() => ({}));
+        setLastAssistant(err.error || "Something went wrong. Please try again.");
+        if (res.status === 402 || res.status === 403) setNotice(err.error || "");
+        setStreaming(false);
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let assistant = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const chunks = buffer.split("\n\n");
+        buffer = chunks.pop() || "";
+        for (const chunk of chunks) {
+          const line = chunk.trim();
+          if (!line.startsWith("data:")) continue;
+          const payload = line.slice(5).trim();
+          if (!payload) continue;
+          let evt: Record<string, unknown>;
+          try {
+            evt = JSON.parse(payload);
+          } catch {
+            continue;
+          }
+          if (evt.type === "meta") {
+            if (evt.conversationId) setActiveId(evt.conversationId as string);
+            if (evt.isNewConversation) refreshConversations();
+          } else if (evt.type === "delta") {
+            assistant += evt.text as string;
+            setLastAssistant(assistant);
+          } else if (evt.type === "step") {
+            setSteps((s) => [...s, evt.tool as string]);
+          } else if (evt.type === "done") {
+            if (typeof evt.balanceCents === "number") setBalanceCents(evt.balanceCents);
+          }
+        }
+      }
+    } catch {
+      setLastAssistant("Network error. Please try again.");
+    } finally {
+      setStreaming(false);
+      setSteps([]);
+      refreshConversations();
+    }
+  }
+
+  async function renameConversation(id: string, current: string) {
+    const title = window.prompt(t.rename, current);
+    if (!title || !title.trim()) return;
+    await fetch(`/api/chat/conversations/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: title.trim() }),
+    });
+    refreshConversations();
+  }
+
+  async function deleteConversation(id: string) {
+    if (!window.confirm(t.deleteConfirm)) return;
+    await fetch(`/api/chat/conversations/${id}`, { method: "DELETE" });
+    if (activeId === id) startNewChat();
+    refreshConversations();
+  }
+
+  const hasMessages = messages.length > 0;
+
+  return (
+    <div className="flex h-[calc(100vh-2rem)] gap-3">
+      {/* Conversation sidebar */}
+      <div className="hidden md:flex md:flex-col md:w-60 shrink-0 bg-white dark:bg-gray-800 rounded-lg shadow-sm overflow-hidden">
+        <div className="p-3">
+          <button
+            onClick={startNewChat}
+            className="w-full px-3 py-2 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+          >
+            + {t.newChat}
+          </button>
+        </div>
+        <div className="px-3 pb-1 text-xs uppercase tracking-wide text-gray-400">{t.history}</div>
+        <div className="flex-1 overflow-y-auto px-2 pb-2 space-y-0.5">
+          {conversations.map((c) => (
+            <div
+              key={c.id}
+              className={`group flex items-center gap-1 rounded-md px-2 py-1.5 text-sm cursor-pointer ${
+                activeId === c.id
+                  ? "bg-blue-50 dark:bg-gray-700 text-blue-700 dark:text-blue-300"
+                  : "hover:bg-gray-100 dark:hover:bg-gray-700/60 text-gray-700 dark:text-gray-300"
+              }`}
+              onClick={() => loadConversation(c.id)}
+            >
+              <span className="flex-1 truncate">{c.title}</span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  renameConversation(c.id, c.title);
+                }}
+                className="opacity-0 group-hover:opacity-100 text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                title={t.rename}
+              >
+                ✎
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  deleteConversation(c.id);
+                }}
+                className="opacity-0 group-hover:opacity-100 text-xs text-gray-400 hover:text-red-500"
+                title={t.delete}
+              >
+                🗑
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Main chat panel */}
+      <div className="flex-1 flex flex-col bg-white dark:bg-gray-800 rounded-lg shadow-sm overflow-hidden">
+        {/* Header: model selector + balance */}
+        <div className="flex items-center justify-between gap-2 border-b border-gray-100 dark:border-gray-700 px-4 py-2">
+          <select
+            value={selectedModel}
+            onChange={(e) => setSelectedModel(e.target.value)}
+            className="text-sm rounded-md border border-gray-200 dark:border-gray-600 bg-transparent px-2 py-1 text-gray-700 dark:text-gray-200 max-w-[60%]"
+          >
+            {models.map((m) => (
+              <option
+                key={m.id}
+                value={m.id}
+                disabled={m.locked}
+                style={{ color: m.locked ? "#9ca3af" : "#111827" }}
+              >
+                {m.provider} · {m.label}
+                {m.locked ? ` 🔒 (${t.locked})` : m.premium ? ` ✦` : ""}
+              </option>
+            ))}
+          </select>
+          {balanceCents !== null && (
+            <span className="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+              {t.balance}: ${(balanceCents / 100).toFixed(2)}
+            </span>
+          )}
+        </div>
+
+        {notice && (
+          <div className="mx-4 mt-3 rounded-md bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-800 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
+            {notice}
+          </div>
+        )}
+
+        {/* Messages */}
+        <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+          {!hasMessages && (
+            <div className="h-full flex flex-col items-center justify-center text-center text-gray-400 gap-4">
+              <p>{t.empty}</p>
+              <div className="flex flex-wrap gap-2 justify-center max-w-md">
+                {t.suggestions.map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => send(s)}
+                    className="text-xs px-3 py-1.5 rounded-full border border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {messages.map((m, i) => (
+            <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
+              <div
+                className={`max-w-[85%] rounded-2xl px-4 py-2.5 text-sm ${
+                  m.role === "user"
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-100"
+                }`}
+              >
+                {m.role === "assistant" ? (
+                  m.content ? (
+                    <div className="prose prose-sm dark:prose-invert max-w-none prose-p:my-1 prose-ul:my-1 prose-pre:my-1">
+                      <ReactMarkdown>{m.content}</ReactMarkdown>
+                    </div>
+                  ) : (
+                    <span className="text-gray-400">
+                      {steps.length > 0 ? `${t.running}: ${steps[steps.length - 1]}…` : t.thinking}
+                    </span>
+                  )
+                ) : (
+                  <span className="whitespace-pre-wrap">{m.content}</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Input */}
+        <div className="border-t border-gray-100 dark:border-gray-700 p-3">
+          <div className="flex items-end gap-2">
+            <textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  send();
+                }
+              }}
+              rows={1}
+              placeholder={t.placeholder}
+              className="flex-1 resize-none rounded-lg border border-gray-200 dark:border-gray-600 bg-transparent px-3 py-2 text-sm text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 max-h-32"
+            />
+            <button
+              onClick={() => send()}
+              disabled={streaming || !input.trim()}
+              className="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {t.send}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/ai-gateway.ts
+++ b/lib/ai-gateway.ts
@@ -11,7 +11,7 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { resolveTextModel } from "./ai-models";
 import type { TokenUsage } from "./usage-tracking";
 
-function getModel(modelId: string) {
+export function getModel(modelId: string) {
   if (modelId.startsWith("openrouter/")) {
     const openrouter = createOpenRouter({
       apiKey: process.env.OPENROUTER_API_KEY,

--- a/lib/ai-models.ts
+++ b/lib/ai-models.ts
@@ -83,54 +83,18 @@ export const TEXT_MODELS: AiTextModel[] = [
     provider: "Mistral",
     description: "Balanced performance",
   },
-  // OpenRouter Free Models
+  // OpenRouter Free Models (verified live on OpenRouter; stale IDs removed).
   {
     id: "openrouter/openai/gpt-oss-120b:free",
     label: "GPT-OSS 120B (Free)",
     provider: "OpenAI",
-    description: "Open-source 120B, free",
-  },
-  {
-    id: "openrouter/nvidia/nemotron-3-super:free",
-    label: "Nemotron 3 Super (Free)",
-    provider: "NVIDIA",
-    description: "543B params, free",
-  },
-  {
-    id: "openrouter/qwen/qwen3-coder-480b-a35b:free",
-    label: "Qwen3 Coder 480B (Free)",
-    provider: "Qwen",
-    description: "Massive MoE, free",
+    description: "Open-source 120B, free — supports tools",
   },
   {
     id: "openrouter/meta-llama/llama-3.3-70b-instruct:free",
     label: "Llama 3.3 70B (Free)",
     provider: "Meta",
     description: "Strong all-rounder, free",
-  },
-  {
-    id: "openrouter/google/gemma-3-27b-it:free",
-    label: "Gemma 3 27B (Free)",
-    provider: "Google",
-    description: "131K context, free",
-  },
-  {
-    id: "openrouter/mistralai/mistral-small-3.1-24b-instruct:free",
-    label: "Mistral Small 3.1 24B (Free)",
-    provider: "Mistral",
-    description: "128K context, free",
-  },
-  {
-    id: "openrouter/deepseek/deepseek-chat-v3-0324:free",
-    label: "DeepSeek V3 (Free)",
-    provider: "DeepSeek",
-    description: "Strong reasoning, free",
-  },
-  {
-    id: "openrouter/nousresearch/hermes-3-llama-3.1-405b:free",
-    label: "Hermes 3 405B (Free)",
-    provider: "Nous",
-    description: "Largest free model",
   },
 ];
 

--- a/lib/auth0.ts
+++ b/lib/auth0.ts
@@ -12,6 +12,27 @@ export interface AuthenticatedUser {
 }
 
 export async function getAuthenticatedUser(): Promise<AuthenticatedUser | null> {
+  // Local-only dev bypass: lets you use the app without Auth0 setup.
+  // Guarded by NODE_ENV !== production AND an explicit env flag.
+  if (process.env.NODE_ENV !== "production" && process.env.DEV_AUTH_BYPASS === "1") {
+    const { prisma } = await import("./db");
+    const devUser = await prisma.user.upsert({
+      where: { auth0Sub: "dev|local" },
+      update: {},
+      create: { auth0Sub: "dev|local", email: "dev@local.test", name: "Dev User" },
+      select: {
+        id: true,
+        auth0Sub: true,
+        email: true,
+        name: true,
+        picture: true,
+        language: true,
+        weixinCookie: true,
+      },
+    });
+    return devUser;
+  }
+
   const session = await auth0.getSession();
   if (!session?.user) {
     return null;

--- a/lib/chat-tools.ts
+++ b/lib/chat-tools.ts
@@ -1,0 +1,157 @@
+/**
+ * Tools exposed to the xPilot AI Studio chatbot. The model can call these to
+ * act on the user's behalf. All tools here are read-only or draft-only (they
+ * never publish to X), so the assistant is safe to use interactively.
+ */
+import { tool, type ToolSet } from "ai";
+import { z } from "zod";
+import { prisma } from "./db";
+import { generateTweetViaGateway } from "./ai-gateway";
+import { fetchTrendingTopics, trendRegionWoeid } from "./trending";
+
+export interface ChatToolContext {
+  userId: string;
+  language: string;
+}
+
+export function buildChatTools(ctx: ChatToolContext): ToolSet {
+  return {
+    generate_posts: tool({
+      description:
+        "Generate draft tweets/posts for X about a topic, using the user's knowledge base for brand voice. Returns drafts only — never publishes.",
+      inputSchema: z.object({
+        topic: z.string().describe("What the posts should be about"),
+        count: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .optional()
+          .describe("How many drafts to produce (default 3)"),
+      }),
+      execute: async ({ topic, count }) => {
+        const n = Math.min(Math.max(count ?? 3, 1), 5);
+        const sources = await prisma.knowledgeSource.findMany({
+          where: { userId: ctx.userId, isActive: true },
+          take: 2,
+          select: { content: true },
+        });
+        const knowledgeContext = sources
+          .map((s) => s.content)
+          .filter(Boolean)
+          .join("\n\n")
+          .slice(0, 2000);
+
+        const drafts: string[] = [];
+        for (let i = 0; i < n; i++) {
+          const r = await generateTweetViaGateway({
+            knowledgeContext,
+            prompt: topic,
+            language: ctx.language,
+          });
+          if (r.success && r.content) drafts.push(r.content.trim());
+        }
+        if (drafts.length === 0)
+          return "Could not generate drafts right now. Please try again.";
+        return drafts.map((d, i) => `Draft ${i + 1}:\n${d}`).join("\n\n");
+      },
+    }),
+
+    get_trending_topics: tool({
+      description:
+        "Fetch current trending news/topics for a region to inspire timely content.",
+      inputSchema: z.object({
+        region: z
+          .enum(["global", "usa", "china"])
+          .optional()
+          .describe("Region to pull trends for (default usa)"),
+      }),
+      execute: async ({ region }) => {
+        const woeid = trendRegionWoeid[region ?? "usa"] ?? trendRegionWoeid.usa;
+        const r = await fetchTrendingTopics(ctx.userId, woeid);
+        if (!r.success || !r.trends?.length) {
+          return r.error || "No trending topics available right now.";
+        }
+        return r.trends
+          .slice(0, 10)
+          .map(
+            (t, i) =>
+              `${i + 1}. ${t.name}${t.description ? ` — ${t.description}` : ""}`,
+          )
+          .join("\n");
+      },
+    }),
+
+    search_knowledge_base: tool({
+      description:
+        "Search the user's own knowledge base (their imported website/brand content) for relevant context.",
+      inputSchema: z.object({
+        query: z.string().describe("What to look for in the knowledge base"),
+      }),
+      execute: async ({ query }) => {
+        const sources = await prisma.knowledgeSource.findMany({
+          where: {
+            userId: ctx.userId,
+            isActive: true,
+            OR: [
+              { name: { contains: query, mode: "insensitive" } },
+              { content: { contains: query, mode: "insensitive" } },
+            ],
+          },
+          take: 3,
+          select: { name: true, url: true, content: true },
+        });
+        if (sources.length === 0)
+          return "No matching knowledge base entries found.";
+        return sources
+          .map(
+            (s) =>
+              `**${s.name}** (${s.url})\n${s.content.slice(0, 400)}${
+                s.content.length > 400 ? "..." : ""
+              }`,
+          )
+          .join("\n\n");
+      },
+    }),
+
+    get_recent_posts_performance: tool({
+      description:
+        "Get the user's recently posted tweets and their engagement metrics, to inform strategy.",
+      inputSchema: z.object({
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(10)
+          .optional()
+          .describe("How many recent posts (default 5)"),
+      }),
+      execute: async ({ limit }) => {
+        const take = Math.min(Math.max(limit ?? 5, 1), 10);
+        const posts = await prisma.post.findMany({
+          where: { userId: ctx.userId, status: "posted" },
+          orderBy: { postedAt: "desc" },
+          take,
+          select: {
+            content: true,
+            impressions: true,
+            likes: true,
+            retweets: true,
+            replies: true,
+            postedAt: true,
+          },
+        });
+        if (posts.length === 0)
+          return "No posted tweets found yet for this account.";
+        return posts
+          .map((p) => {
+            const snippet = p.content.replace(/\s+/g, " ").slice(0, 80);
+            return `- "${snippet}" — ${p.impressions ?? 0} impressions, ${
+              p.likes ?? 0
+            } likes, ${p.retweets ?? 0} retweets, ${p.replies ?? 0} replies`;
+          })
+          .join("\n");
+      },
+    }),
+  };
+}

--- a/lib/chat.ts
+++ b/lib/chat.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared helpers for the xPilot AI Studio chatbot.
+ */
+import type { LanguageModelUsage } from "ai";
+import type { TokenUsage } from "./usage-tracking";
+import { TEXT_MODELS, type AiTextModel } from "./ai-models";
+
+export const CHAT_SOURCE = "chat";
+
+/**
+ * Flagship commercial models reserved for paying subscribers. Free + standard
+ * models stay available to everyone (metered by credits); an active
+ * subscription unlocks these and applies a usage discount.
+ */
+export const PREMIUM_CHAT_MODEL_IDS = new Set<string>([
+  "openai/gpt-4o",
+  "openai/gpt-5",
+  "anthropic/claude-sonnet-4",
+  "google/gemini-2.5-pro",
+  "xai/grok-3",
+  "mistral/mistral-medium",
+]);
+
+export function isPremiumChatModel(modelId: string): boolean {
+  return PREMIUM_CHAT_MODEL_IDS.has(modelId);
+}
+
+export interface ChatModelOption extends AiTextModel {
+  premium: boolean;
+  locked: boolean;
+}
+
+/** Model list for the chat UI, flagged by whether the user can use each one. */
+export function getChatModelOptions(isSubscriber: boolean): ChatModelOption[] {
+  return TEXT_MODELS.map((m) => {
+    const premium = isPremiumChatModel(m.id);
+    return { ...m, premium, locked: premium && !isSubscriber };
+  });
+}
+
+/** How many recent messages to send back to the model for context. */
+export const HISTORY_CONTEXT_LIMIT = 20;
+
+/** Max tool/agent steps the orchestrator may run before answering. */
+export const MAX_CHAT_STEPS = 8;
+
+/** Map the AI SDK v6 usage shape to the project's TokenUsage. */
+export function toTokenUsage(usage?: LanguageModelUsage): TokenUsage {
+  const promptTokens = usage?.inputTokens ?? 0;
+  const completionTokens = usage?.outputTokens ?? 0;
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: usage?.totalTokens ?? promptTokens + completionTokens,
+  };
+}
+
+/** Derive a short conversation title from the first user message. */
+export function deriveTitle(firstMessage: string): string {
+  const clean = firstMessage.trim().replace(/\s+/g, " ");
+  if (!clean) return "New chat";
+  return clean.length > 60 ? clean.slice(0, 57) + "..." : clean;
+}
+
+export function buildChatSystemPrompt(opts: {
+  userName?: string | null;
+  language?: string;
+}): string {
+  const langLine =
+    opts.language === "zh"
+      ? "Reply in 简体中文 unless the user writes in another language."
+      : "Reply in the user's language. Match the language they write in.";
+
+  return `You are xPilot AI, the all-in-one marketing copilot built into xPilot — a social media marketing platform for creators and small businesses.
+
+You help users with social media strategy, content creation, post scheduling, trend and news research, audience growth, and analytics.
+
+What you can help with (and act on through tools when they are available):
+- Draft posts, tweets, and threads for X
+- Plan and schedule recurring/automated posts
+- Research trending topics and current news
+- Search the user's own knowledge base for brand context
+- Review account performance and suggest improvements
+
+Style:
+- Be concise, practical, and friendly. Prefer short paragraphs and bullet points.
+- Use Markdown formatting.
+- ${langLine}
+- When the user asks you to perform an action xPilot supports and a matching tool exists, call the tool instead of only describing it.
+- Never reveal internal infrastructure or upstream provider names.`;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,7 @@
 {
   "nav": {
     "dashboard": "Dashboard",
+    "chat": "AI Chat",
     "gallery": "Gallery",
     "toolbox": "Media Studio",
     "generate": "AI Post Scheduler",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,6 +1,7 @@
 {
   "nav": {
     "dashboard": "仪表盘",
+    "chat": "AI 助手",
     "gallery": "作品展示",
     "toolbox": "媒体工作室",
     "generate": "AI 发帖调度",

--- a/prisma/migrations/20260605050147_add_chat_models/migration.sql
+++ b/prisma/migrations/20260605050147_add_chat_models/migration.sql
@@ -1,0 +1,45 @@
+-- CreateTable
+CREATE TABLE "ChatConversation" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL DEFAULT 'New chat',
+    "model" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ChatConversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChatMessage" (
+    "id" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "model" TEXT,
+    "promptTokens" INTEGER NOT NULL DEFAULT 0,
+    "completionTokens" INTEGER NOT NULL DEFAULT 0,
+    "toolCalls" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "conversationId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ChatMessage_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ChatConversation_userId_updatedAt_idx" ON "ChatConversation"("userId", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "ChatMessage_conversationId_createdAt_idx" ON "ChatMessage"("conversationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ChatMessage_userId_createdAt_idx" ON "ChatMessage"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ChatConversation" ADD CONSTRAINT "ChatConversation_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChatMessage" ADD CONSTRAINT "ChatMessage_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "ChatConversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChatMessage" ADD CONSTRAINT "ChatMessage_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,6 +83,9 @@ model User {
   referredByUser         User?     @relation("Referrals", fields: [referredByUserId], references: [id], onDelete: SetNull)
   referrals              User[]    @relation("Referrals")
   referralCommissions    ReferralCommission[]
+  // AI Studio chatbot
+  chatConversations      ChatConversation[]
+  chatMessages           ChatMessage[]
 }
 
 model CronRunEvent {
@@ -941,5 +944,40 @@ model YouTubeAccount {
   recurringYoutubeSchedules RecurringYoutubeSchedule[]
 
   @@index([userId, isDefault])
+}
+
+// ── AI Studio chatbot ──
+
+model ChatConversation {
+  id        String   @id @default(cuid())
+  title     String   @default("New chat")
+  model     String?  // last model id used in this conversation
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  userId    String
+  user      User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  messages  ChatMessage[]
+
+  @@index([userId, updatedAt])
+}
+
+model ChatMessage {
+  id               String   @id @default(cuid())
+  role             String   // "user" | "assistant" | "system"
+  content          String   // message text (markdown for assistant)
+  model            String?  // model that produced an assistant message
+  promptTokens     Int      @default(0)
+  completionTokens Int      @default(0)
+  toolCalls        String?  // JSON: tool invocations + results for this turn
+  createdAt        DateTime @default(now())
+
+  conversationId   String
+  conversation     ChatConversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  userId           String
+  user             User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([conversationId, createdAt])
+  @@index([userId, createdAt])
 }
 


### PR DESCRIPTION
- Add ChatConversation/ChatMessage Prisma models + migration
- Add streaming /api/chat via AI SDK streamText (multi-model through AI Gateway/OpenRouter)
- Gate premium flagship models behind active subscription; meter usage via credits + tier discount
- Add chat UI (model picker, streaming markdown, conversation sidebar) at /[locale]/chat + nav entry
- Add agent tools: generate_posts, get_trending_topics, search_knowledge_base, get_recent_posts_performance
- Add conversation management API (list / rename / delete)
- Add EN/ZH nav i18n for the chat entry
- Export getModel from ai-gateway; prune dead OpenRouter free model IDs
- Add guarded local-only dev auth bypass (DEV_AUTH_BYPASS, non-production only)