### PR TITLE
feat(desktop): true portable "USB" Windows build

### DIFF
--- a/.github/workflows/build-windows-desktop.yml
+++ b/.github/workflows/build-windows-desktop.yml
@@ -68,7 +68,7 @@ jobs:
           body: |
             xPilot Windows 桌面版（自动构建）。
 
-            - **xPilot-${{ steps.pkg.outputs.version }}-Portable.exe** — U 盘版 / 免安装，双击即用。登录会话与缓存保存在 .exe 同级的 `xPilot-Data/` 文件夹里，拷到 U 盘即可随身携带，换机器免重登、不在宿主机留痕。
+            - **xPilot-${{ steps.pkg.outputs.version }}-Portable.exe** — U 盘版 / 免安装，双击即用（32 位，兼容所有 32/64 位 Windows）。登录会话与缓存保存在 .exe 同级的 `xPilot-Data/` 文件夹里，拷到 U 盘即可随身携带，换机器免重登、不在宿主机留痕。
             - **xPilot-${{ steps.pkg.outputs.version }}-Setup.exe** — 安装版（写入本机 %APPDATA%）。
 
             未做代码签名，首次运行 SmartScreen 拦截时点「更多信息 → 仍要运行」。

--- a/.github/workflows/build-windows-desktop.yml
+++ b/.github/workflows/build-windows-desktop.yml
@@ -68,8 +68,8 @@ jobs:
           body: |
             xPilot Windows 桌面版（自动构建）。
 
-            - **xPilot-${{ steps.pkg.outputs.version }}-Portable.exe** — 免安装，双击即用
-            - **xPilot-${{ steps.pkg.outputs.version }}-Setup.exe** — 安装版
+            - **xPilot-${{ steps.pkg.outputs.version }}-Portable.exe** — U 盘版 / 免安装，双击即用。登录会话与缓存保存在 .exe 同级的 `xPilot-Data/` 文件夹里，拷到 U 盘即可随身携带，换机器免重登、不在宿主机留痕。
+            - **xPilot-${{ steps.pkg.outputs.version }}-Setup.exe** — 安装版（写入本机 %APPDATA%）。
 
             未做代码签名，首次运行 SmartScreen 拦截时点「更多信息 → 仍要运行」。
           files: dist-electron/*.exe

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -22,8 +22,11 @@ win:
   target:
     - target: nsis
       arch: [x64]
+    # Portable ("U 盘版") is built ia32 on purpose: a 32-bit exe runs on every
+    # Windows (32- and 64-bit), so one file works on any machine you plug the
+    # drive into. The app is a thin remote shell, so 32-bit costs nothing here.
     - target: portable
-      arch: [x64]
+      arch: [ia32]
 
 nsis:
   oneClick: false

--- a/electron/main.js
+++ b/electron/main.js
@@ -31,6 +31,25 @@ const isDev = !app.isPackaged;
 let mainWindow = null;
 let tray = null;
 
+// USB / portable build: keep all app state (login session, cookies, cache) in a
+// folder next to the .exe instead of the host's %APPDATA%. This makes it a true
+// "U 盘版": plug the drive into any Windows machine, stay logged in, and leave no
+// trace on the host once it's unplugged. electron-builder injects
+// PORTABLE_EXECUTABLE_DIR only for the `portable` target, so installed builds are
+// unaffected and keep using the standard per-user location.
+function configurePortableDataDir() {
+  const portableDir = process.env.PORTABLE_EXECUTABLE_DIR;
+  if (!portableDir) return;
+  const dataDir = path.join(portableDir, "xPilot-Data");
+  try {
+    // Must run before app `ready`; pins session + cache under the drive folder.
+    app.setPath("userData", dataDir);
+    app.setPath("sessionData", dataDir);
+  } catch {
+    // Read-only drive or locked path — fall back to the default location.
+  }
+}
+
 function iconPath() {
   return path.join(__dirname, "..", "electron-resources", "icon.png");
 }
@@ -149,6 +168,9 @@ function showMainWindow() {
     createWindow();
   }
 }
+
+// Redirect app state to the drive for portable builds. Must run before `ready`.
+configurePortableDataDir();
 
 // Single-instance lock: focus the existing window instead of opening a second.
 const gotLock = app.requestSingleInstanceLock();


### PR DESCRIPTION
## What

Turns the Windows `portable` build into a genuine **USB-drive build**: the app
travels with the drive, stays logged in across machines, and leaves no trace on
the host.

## Why

The `portable` target already produced a single no-install `.exe`, but Electron
still wrote the login session, cookies and cache to the host's `%APPDATA%`. So
the session never travelled with the drive, every new machine required a fresh
login, and traces were left on whatever PC ran it — none of which fits a USB
"plug in anywhere" workflow.

## Changes

- **`electron/main.js`** — when electron-builder runs the portable target it
  injects `PORTABLE_EXECUTABLE_DIR`. Detect it and redirect `userData` /
  `sessionData` to an `xPilot-Data/` folder next to the `.exe`, before app
  `ready`. Installed (nsis) builds are untouched and keep the per-user location.
- **`electron-builder.yml`** — build the portable exe as **ia32** so a single
  file runs on every 32- and 64-bit Windows. The app is a thin remote shell, so
  32-bit carries no meaningful runtime cost. The nsis installer stays x64.
- **`.github/workflows/build-windows-desktop.yml`** — Release notes relabel the
  Portable.exe as the U-disk build and note the broad compatibility.

## Verification

CI built both artifacts on a Windows runner and published them to the
`desktop-v0.1.0` Release; the Portable.exe is now the ia32 USB build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)